### PR TITLE
Update my links

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,7 +915,6 @@ To check the statistics table (GitHub stars/Downloads), please refer to [this pa
 ## Reference
 
  * [自然言語処理の餅屋](https://www.jnlp.org/nlp/top)
- * [フリーで使える日本語の主な大規模言語モデルまとめ](https://zenn.dev/hellorusk/articles/ddee520a5e4318)
  * [yasuokaの日記： 日本語係り受け解析器「2020年の総ざらえ」](https://srad.jp/~yasuoka/journal/643631/)
  * [yasuokaの日記： 日本語係り受け解析器「2021年の総ざらえ」](https://srad.jp/~yasuoka/journal/651542/)
  * https://github.com/topics/japanese?l=python
@@ -928,6 +927,6 @@ To check the statistics table (GitHub stars/Downloads), please refer to [this pa
 
 ## Contributors
 
- * [kaisugi](https://github.com/kaisugi) - [website](https://hellorusk.net)
+ * [kaisugi](https://github.com/kaisugi) - [website](https://kaisugi.me)
  * [bomin0624](https://github.com/bomin0624) - [twitter](https://twitter.com/bomin0624_c)
  * [passaglia](https://github.com/passaglia) - [twitter](https://twitter.com/SamPassaglia)


### PR DESCRIPTION
I've deleted the zenn page because I want llm-jp/awesome-japanese-llm to be referred first.
Also, I've changed the domain for my personal website
Sorry for bothering you 🙏 