### PR TITLE
Add tsukeru-furigana-converter (browser extension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,6 +1089,7 @@ Other libraries for Japanese NLP in JavaScript
  * [japanese-furigana-normalize](https://github.com/marvnc/japanese-furigana-normalize) - Normalize Japanese Furigana
  * [yama](https://github.com/sapjax/yama) - acquire Japanese vocabulary on any website
  * [kaitai](https://github.com/compile10/kaitai) - An application for analyzing Japanese sentence structure using AI. This tool visualizes how words and phrases relate to each other, showing grammatical relationships with interactive diagrams.
+ * [tsukeru-furigana-converter](https://github.com/ln2058/tsukeru-furigana-converter) - Browser extension (Chrome/Edge/Firefox) that injects furigana into Japanese webpages on-demand; includes dictionary tooltips, JLPT filtering, and vocab/Anki export.
 
 
 |Name|downloads/week|total downloads|stars|last commit|


### PR DESCRIPTION
Hi, thank you for maintaining this resource list.

I'd like to suggest adding tsukeru-furigana-converter to the JavaScript → Others section.

Tsukeru is a Chrome/Edge/Firefox extension that inserts furigana (hiragana readings above kanji) into Japanese webpages on-demand. It also includes offline dictionary tooltips, JLPT-level filtering, vocabulary saving, and Anki export.

It is privacy-conscious by design: it only processes/sends text when the user explicitly applies furigana (no background scanning / no tracking).

Happy to adjust the wording or placement if needed. Thank you for your time!

Riamu