### PR TITLE
Add Shirabe Address API — Japanese address normalization REST API for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,6 +1103,7 @@ Other libraries for Japanese NLP in JavaScript
  * [yama](https://github.com/sapjax/yama) - acquire Japanese vocabulary on any website
  * [kaitai](https://github.com/compile10/kaitai) - An application for analyzing Japanese sentence structure using AI. This tool visualizes how words and phrases relate to each other, showing grammatical relationships with interactive diagrams.
  * [tsukeru-furigana-converter](https://github.com/ln2058/tsukeru-furigana-converter) - Browser extension (Chrome/Edge/Firefox) that injects furigana into Japanese webpages on-demand; includes dictionary tooltips, JLPT filtering, and vocab/Anki export.
+ * [techwell-inc-jp/shirabe-address-api](https://github.com/techwell-inc-jp/shirabe-address-api) - AI-native REST API wrapping the Digital Agency's abr-geocoder for Japanese address normalization. Covers all 47 prefectures, returns structured components (prefecture/city/town/block/building/floor) plus postal code and coordinates. OpenAPI 3.1, GPTs Actions, Claude Tool Use, Function Calling ready. CC BY 4.0 attribution required on every response.
 
 
 |Name|downloads/week|total downloads|stars|last commit|
@@ -1129,6 +1130,7 @@ Other libraries for Japanese NLP in JavaScript
 | 🔗 [yama](https://github.com/sapjax/yama) | - | - | ⭐ 8 | 🟢 february|
 | 🔗 [kaitai](https://github.com/compile10/kaitai) | - | - | ⭐ 1 | 🟢 last tuesday|
 | 🔗 [tsukeru-furigana-converter](https://github.com/ln2058/tsukeru-furigana-converter) | - | - | ⭐ 1 | 🟢 last wednesday|
+| 🔗 [techwell-inc-jp/shirabe-address-api](https://github.com/techwell-inc-jp/shirabe-address-api) | - | - | ⭐ 0 | 🟢 today|
 
 
 ## Go


### PR DESCRIPTION
Adds **Shirabe Address API** to the JavaScript / Others section.

## What it is

[techwell-inc-jp/shirabe-address-api](https://github.com/techwell-inc-jp/shirabe-address-api) — an AI-native REST API that normalizes free-form Japanese addresses using the Digital Agency's [Address Base Registry (ABR)](https://www.digital.go.jp/policies/base_registry_address) data and the official [`abr-geocoder`](https://github.com/digital-go-jp/abr-geocoder) engine (MIT). All 47 prefectures, structured components (prefecture/city/town/block/building/floor), postal code, representative coordinates, and a `match_level` field for confidence assessment.

## Why it fits the list

The list already has related Japanese address tools:
- `jageocoder` (line 513, Python > Others) — pure-Python Japanese address geocoder
- `Jusho` (line 173, Python > Converter) — postal code wrapper
- `pygeonlp` (line 514, Python > Others) — geotagging Japanese texts

Shirabe Address API complements these by providing a **REST API service** wrapping `abr-geocoder` (TypeScript / Cloudflare Workers + Fly.io) for callers who don't want to self-host the dictionary (~3 GB SQLite + Trie). It's distinguished from the existing entries by:

- **AI-native design**: OpenAPI 3.1 (full + GPTs short-form), Claude Tool Use, Anthropic SDK, LangChain, Dify, and GPTs Actions all import the spec directly. Designed for LLM tool-use rather than human SDK integration.
- **CC BY 4.0 attribution required**: Every response carries an `attribution` field structurally so that LLMs propagating the data downstream don't drop the source citation.
- **Edge distributed**: Cloudflare Workers (auth/rate-limit/billing), Fly.io NRT (geocoder), no cold start.

## Placement

Added under **JavaScript > Others** since the Workers + Fly.io stack is TypeScript-based. Happy to relocate to a different section if there's a more idiomatic place (e.g., a future "REST APIs" or "Web services" subsection — the list currently doesn't have one but the variety of entries in JavaScript > Others, including [voicevox](https://github.com/VOICEVOX/voicevox) and various browser extensions, suggests this section is broad enough).

## Project status

- License: source MIT, data CC BY 4.0 (ABR)
- Production launch: 2026-05-01 (all 47 prefectures, Phase 1+2 simultaneous)
- Tests: 214 passing
- Operator: Techwell Inc., Fukuoka, Japan
- OpenAPI: <https://shirabe.dev/api/v1/address/openapi.yaml>

Thanks for maintaining this list — it's been a great reference while building shirabe.dev.