### PR TITLE
Add shirabe-sdk (TypeScript) and shirabe-sdk-python — agent-framework tools for Japanese data

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ General-purpose tools supporting Japanese language processing
  * [OneCompression](https://github.com/FujitsuResearch/OneCompression) -  富士通研究所による LLM 向け後学習量子化 (PTQ) パイプライン。QEP (NeurIPS 2025)、ILP 混合精度、回転前処理、vLLM プラグインを統合。論文: [arXiv:2603.28845](https://arxiv.org/abs/2603.28845)。
  * [manga-translator](https://github.com/georgescutelnicu/manga-translator) - Translate text found within speech bubbles in manga images.
  * [shirabe-address-api](https://github.com/techwell-inc-jp/shirabe-address-api) - Shirabe Address API — Japanese address normalization for AI agents (Cloudflare Workers + Fly.io NRT, abr-geocoder backed)
+ * [shirabe-sdk-python](https://github.com/techwell-inc-jp/shirabe-sdk-python) - Official Python SDK for the Shirabe Japan data APIs — ready-made LangChain / OpenAI Agents SDK tools for Japanese name reading (JMnedict-backed candidates), name splitting, address normalization, corporate number lookup, and calendar (rokuyo). Zero-dependency core.
  * [medical-paper-summarizer-public](https://github.com/yush02084/medical-paper-summarizer-public) - 毎日PubMedから最新の循環器内科論文を自動収集・AI要約してGmailに届けるシステム
  * [Irodori-TTS](https://github.com/Aratako/Irodori-TTS) - A Flow Matching-based Text-to-Speech Model with Emoji-driven Style Control
  * [sarashina2.2-tts](https://github.com/sbintuitions/sarashina2.2-tts) - Sarashina2.2-TTS is a Japanese-centric text-to-speech system built on a large language model, developed by SB Intuitions.
@@ -889,6 +890,7 @@ General-purpose tools supporting Japanese language processing
 | 🔗 [OneCompression](https://github.com/FujitsuResearch/OneCompression) | - | - | ⭐ 396 | 🟢 last monday|
 | 🔗 [manga-translator](https://github.com/georgescutelnicu/manga-translator) | - | - | ⭐ 27 | 🟢 april|
 | 🔗 [shirabe-address-api](https://github.com/techwell-inc-jp/shirabe-address-api) | - | - | ⭐ 0 | 🟢 last monday|
+| 🔗 [shirabe-sdk-python](https://github.com/techwell-inc-jp/shirabe-sdk-python) | - | - | ⭐ 0 | 🟢 last friday|
 | 🔗 [medical-paper-summarizer-public](https://github.com/yush02084/medical-paper-summarizer-public) | - | - | ⭐ 19 | 🟢 april|
 | 🔗 [Irodori-TTS](https://github.com/Aratako/Irodori-TTS) | - | - | ⭐ 1k | 🟢 june|
 | 🔗 [sarashina2.2-tts](https://github.com/sbintuitions/sarashina2.2-tts) | - | - | ⭐ 77 | 🟢 june|
@@ -1168,6 +1170,7 @@ Other libraries for Japanese NLP in JavaScript
  * [tsukeru-furigana-converter](https://github.com/ln2058/tsukeru-furigana-converter) - Browser extension (Chrome/Edge/Firefox) that injects furigana into Japanese webpages on-demand; includes dictionary tooltips, JLPT filtering, and vocab/Anki export.
  * [sudachi-synonyms-dictionary](https://github.com/azu/sudachi-synonyms-dictionary) - Sudachi's synonyms dictionary
  * [qmd-ja](https://github.com/joycodetech/qmd-ja) - Japanese-enhanced fork of qmd — Vaporetto WASM morphological tokenizer for accurate Japanese BM25 search
+ * [shirabe-sdk](https://github.com/techwell-inc-jp/shirabe-sdk) - Official TypeScript SDK for the Shirabe Japan data APIs — ready-made Vercel AI SDK / LangChain tools for Japanese name splitting/reading, address normalization, corporate number lookup, and calendar (rokuyo). Zero runtime dependencies in the core.
 
 
 |Name|downloads/week|total downloads|stars|last commit|
@@ -1196,6 +1199,7 @@ Other libraries for Japanese NLP in JavaScript
 | 🔗 [tsukeru-furigana-converter](https://github.com/ln2058/tsukeru-furigana-converter) | - | - | ⭐ 1 | 🟢 may|
 | 🔗 [sudachi-synonyms-dictionary](https://github.com/azu/sudachi-synonyms-dictionary) | - | - | ⭐ 15 | 🟢 may|
 | 🔗 [qmd-ja](https://github.com/joycodetech/qmd-ja) | - | - | ⭐ 2 | 🟢 june|
+| 🔗 [shirabe-sdk](https://github.com/techwell-inc-jp/shirabe-sdk) | - | - | ⭐ 0 | 🟢 last friday|
 
 
 ## Go


### PR DESCRIPTION
Adds two sibling SDKs of the already-listed [shirabe-address-api](https://github.com/techwell-inc-jp/shirabe-address-api) (Python > Others, merged in #19).

## What they are

- [techwell-inc-jp/shirabe-sdk-python](https://github.com/techwell-inc-jp/shirabe-sdk-python) (PyPI: `shirabe-sdk`) — **Python > Others**
- [techwell-inc-jp/shirabe-sdk](https://github.com/techwell-inc-jp/shirabe-sdk) (npm: `shirabe-sdk`) — **JavaScript > Others**

Official SDKs for the Shirabe Japan data APIs. Beyond a thin REST client, both ship ready-made tools for agent frameworks — LangChain and OpenAI Agents SDK (Python), Vercel AI SDK and LangChain (TypeScript) — covering Japanese-NLP-relevant operations: name splitting, personal-name reading estimation with JMnedict-backed alternative candidates (CC BY-SA 4.0, EDRDG licence acknowledged in responses), address normalization (Address Base Registry), corporate number lookup, and calendar (rokuyo). Zero-dependency cores; frameworks are optional extras (`pip install "shirabe-sdk[langchain]"`).

## Why they fit

The list already carries the address API service itself; these entries cover the library/SDK layer that Python and JavaScript developers actually import, in line with other client libraries in both sections. Placement follows #19's precedent (bullet + stats-table row in each section) — happy to relocate or trim to a single entry if you prefer.

Thanks for maintaining this list!